### PR TITLE
Updated URL format and chrome binary location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,8 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+Scripts
+pyvenv.cfg
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+#Ignore any created data.json files during testing
+data.json

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ I want to point out that the `sid` should be a unique identifier for the univers
 
 You must also install ChromeDriver to your machine and specify the path of the ChromeDriver executable in the `driver_config.py` file. You can download the appropriate version for your system [here](https://chromedriver.chromium.org/downloads).
 
+Chrome has changed the way chromedriver and 'automated testing' works with respect to their browser. In order to avoid errors with versioning or unexpected program bugs, it is recommended to install the stable Chrome.exe from the chrome-for-testing site [here](https://googlechromelabs.github.io/chrome-for-testing/). 
+
+After extracting the zip, please add the path of the Chrome.exe to the main `fetch.py` file. This path will be assigned to the `options.binary_location` to ensure minimal issues with ChromeDriver.
+
 Once you have the `sid` and ChromeDriver installed, install the required dependencies and run the script with,
 
 ```{bash}

--- a/rmp_scrape/fetch.py
+++ b/rmp_scrape/fetch.py
@@ -12,7 +12,7 @@ import argparse
 import importlib
 
 # Path to Chrome WebDriver
-import driver_config           
+import rmp_scrape.driver_config as driver_config
 
 # Selenium imports
 from selenium import webdriver                                                  # Webdriver
@@ -22,9 +22,10 @@ from selenium.webdriver.support.ui import WebDriverWait                         
 from selenium.webdriver.support import expected_conditions as EC                # Expected conditions
 from selenium.common.exceptions import TimeoutException, NoSuchElementException # Misc. exceptions
 
+dev_path = 'C:\Program Files (x86)\chrome-win64\chrome.exe'
 path_to_webdriver = driver_config.path_to_webdriver # Init global path to WebDriver
 
-const_rmp_search_url = 'https://www.ratemyprofessors.com/search/teachers?query=*&sid=' # RMP professor search URL
+const_rmp_search_url = 'https://www.ratemyprofessors.com/search/professors/{sid}?q=*' # RMP professor search URL
 
 class RateMyProf:
     """
@@ -37,8 +38,9 @@ class RateMyProf:
         Args: school_id (int): Unique School ID that RateMyProfessor assigns to identify each University.
         """
         self.school_id = school_id                            # Parameter for the school ID
-        self.url = const_rmp_search_url + str(self.school_id) # Query URL for the school ID
-        self.options = webdriver.ChromeOptions()              # Create a new Chrome session
+        self.url = const_rmp_search_url.format(sid=self.school_id) # Query URL for the school ID
+        self.options = webdriver.ChromeOptions() 
+        self.options.binary_location = dev_path             # Create a new Chrome session
         self.options.headless = True
 
         # Ignore SSL certificate errors


### PR DESCRIPTION
Chrome has modified the way 'automated testing' can be performed when using chromedriver.exe. This requires a binary location from the options of the chromedriver to be pointed at chrome.exe. This has been added.

RMP has an updated search URL format, where the sid is no longer at the very end of the URL. with the {SID} at the end of the URL, a 404 error is thrown, even if the given {SID} is correct. The updated URL uses a formatted string, with the sid in the correct location.