### PR TITLE
Prof limit fix

### DIFF
--- a/rmp_scrape/fetch.py
+++ b/rmp_scrape/fetch.py
@@ -122,8 +122,8 @@ class RMPSchool:
                         By.XPATH, new_professor_Xpath)[0]
             return new_prof_elem
         except (IndexError, NoSuchElementException) as  ine:
-            print("New Professor Element not found - Index Path")
-            print("Pressing button and retrying")
+            #print("New Professor Element not found - Index Path")
+            #print("Pressing button and retrying")
 
             # If the show more button is already gone
             # or if, after trying to press it, we find out it's gone
@@ -151,7 +151,7 @@ class RMPSchool:
             self.driver.execute_script(
                             "arguments[0].setAttribute('id', arguments[1]);", self.show_more_button, "RMP_Scrape")
         except Exception as e:
-            print(f"Set Show More Button: Some error occurred \n {e.msg}")
+            #print(f"Set Show More Button: Some error occurred \n {e.msg}")
             raise e
 
     def push_show_more_button(self, mod_eight=False):
@@ -172,7 +172,7 @@ class RMPSchool:
             # The reference to the button is stale, attempt to find it again
             try:
                 self.set_show_more_button()
-                print("Searching for more Professors, Again...")
+                #print("Searching for more Professors, Again...")
                 self.driver.execute_script(
                     "arguments[0].click();", self.show_more_button)
                 self.show_more_button = ""
@@ -187,7 +187,8 @@ class RMPSchool:
                 self.show_more_button = ""
                 return ""
         except Exception as e:
-            print(f"Push SHow More Button: Some error occured - {e.msg}")
+            #print(f"Push SHow More Button: Some error occured - {e.msg}")
+            return 
 
     def get_professors_list(self):
         """Fetches the list of professors from the professors search endpoint.

--- a/rmp_scrape/fetch.py
+++ b/rmp_scrape/fetch.py
@@ -48,7 +48,7 @@ class RMPSchool:
 
         # Instantiate Chrome Options
         self.options = webdriver.ChromeOptions()
-        # self.options.add_argument('--headless')
+        self.options.add_argument('--headless')
         self.options.add_argument('--ignore-certificate-errors')
         self.options.add_argument('--ignore-ssl-errors')
         self.options.add_argument('log-level=3')
@@ -201,7 +201,6 @@ class RMPSchool:
         professor_idx = 0
         while not self.scrape_complete:
             try:
-                print("New Iteration started")
                 professor_idx += 1
                 new_professor_text = ""
                 new_prof_elem = self.gen_next_professor_element(professor_idx)
@@ -213,7 +212,7 @@ class RMPSchool:
                 professor_attr_list = new_professor_text.split('\n')
                 new_prof_obj = RMPProfessor(professor_attr_list)
                 self.professors_list.append(new_prof_obj)
-                print(f"{professor_idx} Professors Fetched")
+                print(new_prof_obj)
 
                 if professor_idx % 8 == 0:
                     self.push_show_more_button(mod_eight=True)

--- a/static_data/universityofwisconsin_madison_professors.csv
+++ b/static_data/universityofwisconsin_madison_professors.csv
@@ -1,9 +1,0 @@
-name,department,rating,num_ratings,would_take_again_pct,level_of_difficulty
-Rod Matthews,Business,2.9,35,N/A,2.9
-Barry Ganetzky,Genetics,4.5,7,N/A,2.9
-Stanley Dodson,Science,3.3,16,N/A,2.4
-Mike Plesha,Engineering,3.9,80,84%,3.2
-Lea Jacobs,Communication,2.3,7,N/A,3.6
-Luis Madureira,English,3.8,12,0%,2.3
-Thomas Schaub,English,3.5,40,N/A,2.7
-Jeffery Steele,English,3.8,64,43%,2.7


### PR DESCRIPTION
Fixed the issue that limited the number of professors that could be scraped from the site. 
Broke some functionalities out into their own functions for better error handling and traceability. 
The tool can now scrape all professors from a university as big as University of Wisconsin. 

Note: The number of professors scraped will not be equal to the number displayed on the site. This is most likely an issue on RMP's backend. Paging the results until the button disappears, the total number of professors displayed is not the same, but this change accounts for both reaching the end of the results and reaching the number displayed on the page when deciding when to stop. 